### PR TITLE
chore(global): Setup entry point for npm package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  email: require('./browser/email'),
+  imap: require('./server/imap'),
+  netlify: require('./server/netlify'),
+  netlifyAdapters: require('./server/netlifyAdapters'),
+  apiActions: require('./shared/apiActions'),
+  userData: require('./shared/userData'),
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@3blades/cypress-test-utils",
   "version": "0.0.0-development",
   "description": "Utilities for testing with Cypress",
+  "main": "index.js",
   "scripts": {
     "test": "jest --watch",
     "test:ci": "jest --coverage",


### PR DESCRIPTION
Added an entrypoint to the npm package so that it can be required normally. index.js points to all
the usable modules in the package so they can be directly referenced when requiring the package.